### PR TITLE
00011-easy-tuple-to-object

### DIFF
--- a/playground/00011-easy-tuple-to-object.ts
+++ b/playground/00011-easy-tuple-to-object.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/comma-dangle */
+/* eslint-disable @typescript-eslint/quotes */
 /*
   11 - Tuple to Object
   -------
@@ -19,20 +21,35 @@
 */
 
 /* _____________ Your Code Here _____________ */
+type Key = string | number | symbol
 
-type TupleToObject<T extends readonly any[]> = any
+type TupleToObject<T extends readonly Key[]> = {
+  [P in T[number]]: P
+}
 
 /* _____________ Test Cases _____________ */
-import type { Equal, Expect } from '@type-challenges/utils'
+import type { Equal, Expect } from "@type-challenges/utils"
 
-const tuple = ['tesla', 'model 3', 'model X', 'model Y'] as const
+const tuple = ["tesla", "model 3", "model X", "model Y"] as const
 const tupleNumber = [1, 2, 3, 4] as const
-const tupleMix = [1, '2', 3, '4'] as const
+const tupleMix = [1, "2", 3, "4"] as const
 
 type cases = [
-  Expect<Equal<TupleToObject<typeof tuple>, { tesla: 'tesla'; 'model 3': 'model 3'; 'model X': 'model X'; 'model Y': 'model Y' }>>,
+  Expect<
+    Equal<
+      TupleToObject<typeof tuple>,
+      {
+        tesla: "tesla"
+        "model 3": "model 3"
+        "model X": "model X"
+        "model Y": "model Y"
+      }
+    >
+  >,
   Expect<Equal<TupleToObject<typeof tupleNumber>, { 1: 1; 2: 2; 3: 3; 4: 4 }>>,
-  Expect<Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4' }>>,
+  Expect<
+    Equal<TupleToObject<typeof tupleMix>, { 1: 1; "2": "2"; 3: 3; "4": "4" }>
+  >
 ]
 
 // @ts-expect-error
@@ -43,4 +60,5 @@ type error = TupleToObject<[[1, 2], {}]>
   > Share your solutions: https://tsch.js.org/11/answer
   > View solutions: https://tsch.js.org/11/solutions
   > More Challenges: https://tsch.js.org
+  > index signatures: https://basarat.gitbook.io/typescript/type-system/index-signatures
 */


### PR DESCRIPTION
```ts
type Key = string | number | symbol

type TupleToObject<T extends readonly Key[]> = {
  [P in T[number]]: P
}
```