### PR TITLE
00014-easy-first-of-array

### DIFF
--- a/notes/00014-easy-first-of-array.md
+++ b/notes/00014-easy-first-of-array.md
@@ -1,0 +1,33 @@
+```
+Exported with AIPRM https://www.aiprm.com by J H on 2023. 3. 28. 오후 11:45:09
+```
+
+---
+
+**User:**
+which one is better?
+
+type First<T extends unknown[]> = T extends [] ? never : T[0]
+type First<T extends unknown[]> = T extends never[] ? never : T[0]
+type First<T extends any[]> = T extends [infer P, ...infer rest] ? P : never
+
+---
+
+**ChatGPT:**
+All three of these TypeScript types are designed to extract the first element from an array type. However, they differ slightly in their implementation and usage.
+The first type definition <code>First&lt;T extends unknown[]&gt; = T extends [] ? never : T[0]</code> uses the conditional type syntax to check if the input array is an empty array <code>[]</code>. If it is empty, it returns the <code>never</code> type, and if it is not empty, it returns the first element of the array.
+The second type definition <code>First&lt;T extends unknown[]&gt; = T extends never[] ? never : T[0]</code> also uses the conditional type syntax but checks if the input array is of type <code>never[]</code> instead of <code>[]</code>. If the input array is of type <code>never[]</code>, it returns the <code>never</code> type, and if it is not of type <code>never[]</code>, it returns the first element of the array.
+The third type definition <code>First&lt;T extends any[]&gt; = T extends [infer P, ...infer rest] ? P : never</code> uses the <code>infer</code> keyword to extract the first element of the input array <code>T</code> and assign it to the type parameter <code>P</code>. It then returns the type <code>P</code> if the input array matches the pattern <code>[P, ...rest]</code>, or <code>never</code> if it does not match this pattern.
+In terms of which one is "better," it depends on your specific use case and the requirements of your code. All three type definitions are valid and will work correctly to extract the first element of an array type. The choice of which one to use may depend on factors such as performance, readability, or the specific needs of your project.
+
+---
+
+**User:**
+which one has better performance?
+
+---
+
+**ChatGPT:**
+In terms of performance, it's difficult to say definitively which of the three type definitions is the fastest, as it can depend on factors such as the size of the input array and the complexity of other type operations being performed alongside this type.
+However, the third type definition <code>First&lt;T extends any[]&gt; = T extends [infer P, ...infer rest] ? P : never</code> may have slightly better performance than the other two, because it uses the <code>infer</code> keyword to extract the first element of the array type in a single operation, rather than checking for the presence of an empty array or an array of type <code>never[]</code>.
+That being said, the performance differences between these three type definitions are likely to be very small, and may not be noticeable in most real-world use cases. Therefore, the choice of which type definition to use should primarily depend on factors such as readability, maintainability, and suitability for the specific use case.

--- a/playground/00014-easy-first-of-array.ts
+++ b/playground/00014-easy-first-of-array.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/comma-dangle */
+/* eslint-disable @typescript-eslint/quotes */
 /*
   14 - First of Array
   -------
@@ -22,23 +24,25 @@
 
 /* _____________ Your Code Here _____________ */
 
-type First<T extends any[]> = any
+type First<T extends unknown[]> = T extends [] ? never : T[0]
+// type First<T extends unknown[]> = T extends never[] ? never : T[0]
+// type First<T extends any[]> = T extends [infer P, ...infer rest] ? P : never
 
 /* _____________ Test Cases _____________ */
-import type { Equal, Expect } from '@type-challenges/utils'
+import type { Equal, Expect } from "@type-challenges/utils"
 
 type cases = [
   Expect<Equal<First<[3, 2, 1]>, 3>>,
   Expect<Equal<First<[() => 123, { a: string }]>, () => 123>>,
   Expect<Equal<First<[]>, never>>,
-  Expect<Equal<First<[undefined]>, undefined>>,
+  Expect<Equal<First<[undefined]>, undefined>>
 ]
 
 type errors = [
   // @ts-expect-error
-  First<'notArray'>,
+  First<"notArray">,
   // @ts-expect-error
-  First<{ 0: 'arrayLike' }>,
+  First<{ 0: "arrayLike" }>
 ]
 
 /* _____________ Further Steps _____________ */


### PR DESCRIPTION
```ts
type First<T extends unknown[]> = T extends [] ? never : T[0]
```

```ts
type First<T extends unknown[]> = T extends never[] ? never : T[0]
```

```ts
type First<T extends any[]> = T extends [infer P, ...infer rest] ? P : never
```

위의 세 가지의 방법을 생각해보았는데,
가장 가독성이 좋은 쪽이 첫 번째 방법이라고 생각해서 첫 번째 방법으로 결정했습니다.

성능상으로는 infer를 이용한 세 번째 방법이 약간 더 좋지만, 정말 미미한 차이라서 가독성이 좋은 쪽을 선택하는 것이 좋다고 판단했습니다.
```
`infer`를 이용한 세 번째 방법이 성능이 약간 더 좋은 이유:
빈 배열이나 never[] 타입의 배열의 존재 여부를 확인하는 대신 infer 키워드를 사용하여 배열 타입에서 첫 번째 요소를 한 번에 추출하기 때문
```

## 참고
### `infer` 키워드란?
The 'infer' keyword in TypeScript is used in conditional types to infer the type of a type parameter from a given expression. In other words, it allows TypeScript to automatically determine the type of a value based on the context in which it is used.

```ts
type ReturnType2<T> = T extends (...args: any[]) => infer R ? R : never
function add(x: number, y: number): number {
  return x + y;
}

type AddReturnType = ReturnType<typeof add>; // AddReturnType is inferred as `number`
```

In this example, the 'infer' keyword is used to infer the return type of the 'add' function, which is a number. The inferred type is then assigned to the 'AddReturnType' type alias.

The 'infer' keyword is a powerful feature of TypeScript that allows for more concise and expressive type definitions, and is commonly used in advanced type system constructs such as conditional types and mapped types.