### PR TITLE
00002-medium-get-return-type

### DIFF
--- a/playground/00002-medium-get-return-type.ts
+++ b/playground/00002-medium-get-return-type.ts
@@ -25,7 +25,9 @@
 
 /* _____________ Your Code Here _____________ */
 
-type MyReturnType<T> = any
+type MyReturnType<T extends Function> = T extends (...args: any) => infer R
+  ? R
+  : never
 
 /* _____________ Test Cases _____________ */
 import type { Equal, Expect } from '@type-challenges/utils'
@@ -46,8 +48,8 @@ type ComplexObject = {
   prev(): number
 }
 
-const fn = (v: boolean) => v ? 1 : 2
-const fn1 = (v: boolean, w: any) => v ? 1 : 2
+const fn = (v: boolean) => (v ? 1 : 2)
+const fn1 = (v: boolean, w: any) => (v ? 1 : 2)
 
 /* _____________ Further Steps _____________ */
 /*


### PR DESCRIPTION
```ts
type MyReturnType<T extends Function> = T extends (...args: any) => infer R
  ? R
  : never
```